### PR TITLE
Remove .v add .sv from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@
 !*/
 !*.txt
 # VHDL
-!*.v
+# IMPORTANT! Use .sv for SystemVerilog 2006 Standard instead of .v for Verliog 2001 standard. (.v intentionally removed)
+!*.sv
 !*.vhdl
 !*.vhd
 # Quartus


### PR DESCRIPTION
To force use of SystemVerilog 2006 standards in Quartus etc.